### PR TITLE
[🛠Refactor] 사용자 로그 추가 & 파워유저 정렬(등수) 변경

### DIFF
--- a/src/main/java/com/codeit/duckhu/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/controller/UserController.java
@@ -18,6 +18,7 @@ import jakarta.validation.Valid;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -109,7 +111,12 @@ public class UserController implements UserApi {
 
   @Override
   @GetMapping("/power")
-  public ResponseEntity<CursorPageResponsePowerUserDto> findPowerUsers(PeriodType period, Direction direction, String cursor, Instant after, int limit) {
+  public ResponseEntity<CursorPageResponsePowerUserDto> findPowerUsers(
+          @RequestParam PeriodType period,
+          @RequestParam(defaultValue = "ASC") Direction direction,
+          @RequestParam(required = false) String cursor,
+          @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant after,
+          @RequestParam(defaultValue = "50") int limit) {
     CursorPageResponsePowerUserDto result = userService.findPowerUsers(period, direction, cursor, after, limit);
     return ResponseEntity.status(HttpStatus.OK).body(result);
   }

--- a/src/main/java/com/codeit/duckhu/domain/user/repository/poweruser/PowerUserRepositoryImpl.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/repository/poweruser/PowerUserRepositoryImpl.java
@@ -108,9 +108,11 @@ public class PowerUserRepositoryImpl implements PowerUserRepositoryCustom {
     condition.and(powerUser.period.eq(period));
     condition.and(user.deleted.eq(false));
 
+    //커서 있을경우 조건 추가해서 이후 데이터 조회
     if(cursor != null && after != null) {
       condition.and(getCursorCondition(cursor, after, isAsc(direction)));
     }
+    //정렬기준 생성
     List<OrderSpecifier<?>> orders = getOrderSpecifiers(isAsc(direction));
 
     return queryFactory
@@ -128,7 +130,7 @@ public class PowerUserRepositoryImpl implements PowerUserRepositoryCustom {
 
   private List<OrderSpecifier<?>> getOrderSpecifiers(boolean asc) {
     List<OrderSpecifier<?>> orders = new ArrayList<>();
-    orders.add(asc ? powerUser.score.asc() : powerUser.score.desc());
+    orders.add(asc ? powerUser.rank.asc() : powerUser.rank.desc());
     orders.add(asc ? powerUser.createdAt.asc() : powerUser.createdAt.desc());
     orders.add(asc ? powerUser.user.id.asc() : powerUser.user.id.desc());
     return orders;

--- a/src/main/java/com/codeit/duckhu/domain/user/service/PowerUserBatchScheduler.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/service/PowerUserBatchScheduler.java
@@ -12,24 +12,20 @@ import org.springframework.stereotype.Component;
 public class PowerUserBatchScheduler {
     private final UserService userService;
 
-    @Scheduled(cron = "0 0 0 * * *")
-    public void dailySchedule() {
-        log.info("PowerUser DAILY 배치 시작");
-        userService.savePowerUser(PeriodType.DAILY);
-        log.info("PowerUser DAILY 배치 완료");
-    }
+    @Scheduled(cron = "0 0 12 * * *")
+    public void schedule() {
+        executePopularBookBatch(PeriodType.DAILY, "[일간 배치 작업]");
+        executePopularBookBatch(PeriodType.WEEKLY, "[주간 배치 작업]");
+        executePopularBookBatch(PeriodType.MONTHLY, "[월간 배치 작업]");
+        executePopularBookBatch(PeriodType.ALL_TIME, "[역대 배치 작업]");
 
-    @Scheduled(cron = "0 0 0 * * 0")
-    public void weeklySchedule() {
-        log.info("PowerUser Weekly 배치 시작");
-        userService.savePowerUser(PeriodType.WEEKLY);
-        log.info("PowerUser Weekly 배치 완료");
     }
-
-    @Scheduled(cron = "0 0 0 1 * *")
-    public void monthlySchedule() {
-        log.info("PowerUser Monthly 배치 시작");
-        userService.savePowerUser(PeriodType.MONTHLY);
-        log.info("PowerUser Monthly 배치 완료");
+    private void executePopularBookBatch(PeriodType period, String logPrefix) {
+        try {
+            log.info("{} {} 파워 유저를 갱신합니다.", logPrefix, period);
+            userService.savePowerUser(period);
+        } catch (Exception e) {
+            log.error("{} {} 파워 유저 갱신 중 오류 발생 {}", logPrefix, period, e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/codeit/duckhu/domain/user/service/PowerUserBatchScheduler.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/service/PowerUserBatchScheduler.java
@@ -25,7 +25,7 @@ public class PowerUserBatchScheduler {
             log.info("{} {} 파워 유저를 갱신합니다.", logPrefix, period);
             userService.savePowerUser(period);
         } catch (Exception e) {
-            log.error("{} {} 파워 유저 갱신 중 오류 발생 {}", logPrefix, period, e.getMessage());
+            log.warn("{} {} 파워 유저 갱신 중 오류 발생 {}", logPrefix, period, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
@@ -139,7 +139,7 @@ public class UserServiceImpl implements UserService {
     //유저목록가져오기
     Set<UUID> userIds = stats.stream().map(PowerUserStatsDto::userId).collect(Collectors.toSet());
     Map<UUID, User> userMap = userRepository.findAllById(userIds).stream()
-            .collect(Collectors.toMap(User::getId, Function.identity()));
+            .collect(Collectors.toMap(User::getId, Function.identity()));//
 
     //활동점수 계산
     List<PowerUser> powerUsers = stats.stream()
@@ -180,6 +180,7 @@ public class UserServiceImpl implements UserService {
     List<PowerUser> powerUsers = powerUserRepository.searchByPeriodWithCursorPaging(
             period, direction, cursor, after, limit + 1
     );
+
     boolean hasNext = powerUsers.size() > limit;
 
     //저장된 PowerUser 커서페이지로 갖고오기

--- a/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
@@ -31,9 +31,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -46,12 +48,14 @@ public class UserServiceImpl implements UserService {
   @Override
   public UserDto create(UserRegisterRequest request) {
     if (userRepository.existsByEmail(request.getEmail())) {
+      log.warn("[사용자 등록 실패] 이메일 중복: {}", request.getEmail());
       throw new EmailDuplicateException(ErrorCode.EMAIL_DUPLICATION);
     }
 
     User user = new User(request.getEmail(), request.getNickname(), request.getPassword());
 
     User savedUser = userRepository.save(user);
+    log.info("[사용자 등록 완료] id: {}, nickname : {}", savedUser.getId(), savedUser.getNickname());
 
     return userMapper.toDto(savedUser);
   }
@@ -64,10 +68,15 @@ public class UserServiceImpl implements UserService {
     User user =
         userRepository
             .findByEmail(email)
-            .orElseThrow(() -> new InvalidLoginException(ErrorCode.LOGIN_INPUT_INVALID));
+            .orElseGet(() -> {
+              log.warn("[로그인 실패] 존재하지 않는 이메일: {}", email);
+              throw new InvalidLoginException(ErrorCode.LOGIN_INPUT_INVALID);
+            });
     if (!user.getPassword().equals(password)) {
+      log.warn("[로그인 실패] 일치하지 않는 비밀번호: {}", password);
       throw new InvalidLoginException(ErrorCode.LOGIN_INPUT_INVALID);
     }
+    log.info("[로그인 완료] 사용자 ID: {}, 이메일: {}", user.getId(), email);
     return userMapper.toDto(user);
   }
 
@@ -77,8 +86,12 @@ public class UserServiceImpl implements UserService {
     User user =
         userRepository
             .findById(id)
-            .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+            .orElseGet(() ->{
+              log.warn("[사용자 조회 실패] id: {}", id);
+              throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
+            });
     if (user.isDeleted()) {
+      log.warn("[사용자 조회 실패] 논리 삭제된 id: {}", id);
       throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
     }
     return userMapper.toDto(user);
@@ -89,8 +102,13 @@ public class UserServiceImpl implements UserService {
     User user =
         userRepository
             .findById(id)
-            .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+            .orElseGet(() -> {
+              log.warn("[사용자 조회 실패] id: {}", id);
+              throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
+            });
+
     if (user.isDeleted()) {
+      log.warn("[사용자 조회 실패] 논리 삭제된 id: {}", id);
       throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
     }
     user.update(userUpdateRequest);
@@ -101,8 +119,13 @@ public class UserServiceImpl implements UserService {
     User user =
         userRepository
             .findById(id)
-            .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+            .orElseGet(() -> {
+              log.warn("[사용자 조회 실패] id: {}", id);
+              throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
+            });
+
     if (user.isDeleted()) {
+      log.warn("[사용자 조회 실패] 논리 삭제된 id: {}", id);
       throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
     }
 
@@ -114,8 +137,13 @@ public class UserServiceImpl implements UserService {
     User user =
         userRepository
             .findById(id)
-            .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+                .orElseGet(() -> {
+                  log.warn("[사용자 조회 실패] id: {}", id);
+                  throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
+                });
+
     user.softDelete();
+    log.info("[사용자 논리 삭제 완료] id: {}", id);
   }
 
   @Override
@@ -123,53 +151,71 @@ public class UserServiceImpl implements UserService {
     User user =
         userRepository
             .findById(id)
-            .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+                .orElseGet(() -> {
+                  log.warn("[사용자 조회 실패] id: {}", id);
+                  throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
+                });
+
     userRepository.deleteById(user.getId());
+    log.warn("[사용자 물리 삭제 완료] id: {}", id); //정상적이지만 주의가 필요한 행동이니까 warn
   }
 
   @Override
   public void savePowerUser(PeriodType period) {
-    Instant now = Instant.now();
-    Instant start = period.toStartInstant(now);
-    Instant end = now;
+   try {
+     Instant now = Instant.now();
+     Instant start = period.toStartInstant(now);
+     Instant end = now;
 
-    // 계산에 필요한 요소들 갖고오기
-    List<PowerUserStatsDto> stats = powerUserRepository.findPowerUserStatsBetween(start, end);
+     log.info("[Batch 시작] period={} | from={} ~ to={}", period, start, now);
 
-    //유저목록가져오기
-    Set<UUID> userIds = stats.stream().map(PowerUserStatsDto::userId).collect(Collectors.toSet());
-    Map<UUID, User> userMap = userRepository.findAllById(userIds).stream()
-            .collect(Collectors.toMap(User::getId, Function.identity()));//
+     // 계산에 필요한 요소들 갖고오기
+     List<PowerUserStatsDto> stats = powerUserRepository.findPowerUserStatsBetween(start, end);
 
-    //활동점수 계산
-    List<PowerUser> powerUsers = stats.stream()
-            .map(dto -> {
-              Double score = dto.reviewScoreSum() * 0.5
-                      + dto.likedCount() * 0.2
-                      + dto.commentCount() * 0.3;
-              User user = Optional.ofNullable(userMap.get(dto.userId()))
-                      .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
+     //유저목록가져오기
+     Set<UUID> userIds = stats.stream().map(PowerUserStatsDto::userId).collect(Collectors.toSet());
+     Map<UUID, User> userMap = userRepository.findAllById(userIds).stream()
+             .collect(Collectors.toMap(User::getId, Function.identity()));
 
-              return PowerUser.builder()
-                      .user(user)
-                      .reviewScoreSum(dto.reviewScoreSum())
-                      .likeCount(dto.likedCount())
-                      .commentCount(dto.commentCount())
-                      .score(score)
-                      .period(period)
-                      .build();
-            })
-            .sorted(Comparator.comparingDouble(PowerUser::getScore).reversed())
-            .toList();
+     //활동점수 계산
+     List<PowerUser> powerUsers = stats.stream()
+             .map(dto -> {
+               Double score = dto.reviewScoreSum() * 0.5
+                       + dto.likedCount() * 0.2
+                       + dto.commentCount() * 0.3;
+               User user = Optional.ofNullable(userMap.get(dto.userId()))
+                       .orElseThrow(() -> new NotFoundUserException(ErrorCode.NOT_FOUND_USER));
 
-    //순위 부여-동시성제어
-    AtomicInteger rankCount = new AtomicInteger(1);
-    //순위 설정
-    powerUsers.forEach(powerUser -> powerUser.setRank(rankCount.getAndIncrement()));
-    //기존 데이터 삭제(for 배치)
-    powerUserRepository.deleteByPeriod(period);
-    //PowerUser에 저장
-    powerUserRepository.saveAll(powerUsers);
+               log.info("파워유저: {} | 활동 점수: {} | 리뷰 점수 합: {} | 좋아요 수: {} | 댓글 수: {}",
+                       user.getNickname(),score,dto.reviewScoreSum(),dto.likedCount(),dto.commentCount());
+
+               return PowerUser.builder()
+                       .user(user)
+                       .reviewScoreSum(dto.reviewScoreSum())
+                       .likeCount(dto.likedCount())
+                       .commentCount(dto.commentCount())
+                       .score(score)
+                       .period(period)
+                       .build();
+             })
+             .sorted(Comparator.comparingDouble(PowerUser::getScore).reversed())
+             .toList();
+
+     //순위 부여-동시성제어
+     AtomicInteger rankCount = new AtomicInteger(1);
+     //순위 설정
+     powerUsers.forEach(powerUser -> powerUser.setRank(rankCount.getAndIncrement()));
+
+     //기존 데이터 삭제(for 배치)
+     powerUserRepository.deleteByPeriod(period);
+     log.info("[삭제 완료] 기존 PowerUser 삭제 - period={}", period);
+
+     //PowerUser에 저장
+     powerUserRepository.saveAll(powerUsers);
+     log.info("[PowerUser 저장 완료] 대상 수: {}, period={}", powerUsers.size(), period);
+   }catch (Exception e) {
+     log.error("[Batch 오류] period = {} 처리 중 오류 발생 : {}", period, e.getMessage());
+   }
   }
 
   @Override

--- a/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
@@ -48,7 +48,7 @@ public class UserServiceImpl implements UserService {
   @Override
   public UserDto create(UserRegisterRequest request) {
     if (userRepository.existsByEmail(request.getEmail())) {
-      log.warn("[사용자 등록 실패] 이메일 중복: {}", request.getEmail());
+      log.info("[사용자 등록 실패] 이메일 중복: {}", request.getEmail());
       throw new EmailDuplicateException(ErrorCode.EMAIL_DUPLICATION);
     }
 
@@ -69,11 +69,11 @@ public class UserServiceImpl implements UserService {
         userRepository
             .findByEmail(email)
             .orElseGet(() -> {
-              log.warn("[로그인 실패] 존재하지 않는 이메일: {}", email);
+              log.info("[로그인 실패] 존재하지 않는 이메일: {}", email);
               throw new InvalidLoginException(ErrorCode.LOGIN_INPUT_INVALID);
             });
     if (!user.getPassword().equals(password)) {
-      log.warn("[로그인 실패] 일치하지 않는 비밀번호: {}", password);
+      log.info("[로그인 실패] 일치하지 않는 비밀번호: {}", password);
       throw new InvalidLoginException(ErrorCode.LOGIN_INPUT_INVALID);
     }
     log.info("[로그인 완료] 사용자 ID: {}, 이메일: {}", user.getId(), email);
@@ -87,11 +87,11 @@ public class UserServiceImpl implements UserService {
         userRepository
             .findById(id)
             .orElseGet(() ->{
-              log.warn("[사용자 조회 실패] id: {}", id);
+              log.info("[사용자 조회 실패] id: {}", id);
               throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
             });
     if (user.isDeleted()) {
-      log.warn("[사용자 조회 실패] 논리 삭제된 id: {}", id);
+      log.info("[사용자 조회 실패] 논리 삭제된 id: {}", id);
       throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
     }
     return userMapper.toDto(user);
@@ -103,12 +103,12 @@ public class UserServiceImpl implements UserService {
         userRepository
             .findById(id)
             .orElseGet(() -> {
-              log.warn("[사용자 조회 실패] id: {}", id);
+              log.info("[사용자 조회 실패] id: {}", id);
               throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
             });
 
     if (user.isDeleted()) {
-      log.warn("[사용자 조회 실패] 논리 삭제된 id: {}", id);
+      log.info("[사용자 조회 실패] 논리 삭제된 id: {}", id);
       throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
     }
     user.update(userUpdateRequest);
@@ -120,12 +120,12 @@ public class UserServiceImpl implements UserService {
         userRepository
             .findById(id)
             .orElseGet(() -> {
-              log.warn("[사용자 조회 실패] id: {}", id);
+              log.info("[사용자 조회 실패] id: {}", id);
               throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
             });
 
     if (user.isDeleted()) {
-      log.warn("[사용자 조회 실패] 논리 삭제된 id: {}", id);
+      log.info("[사용자 조회 실패] 논리 삭제된 id: {}", id);
       throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
     }
 
@@ -138,7 +138,7 @@ public class UserServiceImpl implements UserService {
         userRepository
             .findById(id)
                 .orElseGet(() -> {
-                  log.warn("[사용자 조회 실패] id: {}", id);
+                  log.info("[사용자 조회 실패] id: {}", id);
                   throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
                 });
 
@@ -152,12 +152,12 @@ public class UserServiceImpl implements UserService {
         userRepository
             .findById(id)
                 .orElseGet(() -> {
-                  log.warn("[사용자 조회 실패] id: {}", id);
+                  log.info("[사용자 조회 실패] id: {}", id);
                   throw new NotFoundUserException(ErrorCode.NOT_FOUND_USER);
                 });
 
     userRepository.deleteById(user.getId());
-    log.warn("[사용자 물리 삭제 완료] id: {}", id); //정상적이지만 주의가 필요한 행동이니까 warn
+    log.warn("[사용자 물리 삭제 완료] id: {}", id); //정상적이지만 주의가 필요한 행동(복구 불가능한 행위)이니까 warn
   }
 
   @Override
@@ -214,7 +214,7 @@ public class UserServiceImpl implements UserService {
      powerUserRepository.saveAll(powerUsers);
      log.info("[PowerUser 저장 완료] 대상 수: {}, period={}", powerUsers.size(), period);
    }catch (Exception e) {
-     log.error("[Batch 오류] period = {} 처리 중 오류 발생 : {}", period, e.getMessage());
+     log.warn("[Batch 오류] period = {} 처리 중 오류 발생 : {}", period, e.getMessage()); //배치작업 오류 그냥 넘어가면 안되니까
    }
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,7 @@ spring:
     driver-class-name: org.h2.Driver
   sql:
     init:
-      mode: never # 도서 테이블이랑 엔티티랑 달라서 테스트가 되지 않아 never로 우선 설정해두었습니다.
+      mode: always
       data-locations: classpath:data.sql
   jpa:
     hibernate:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,7 +9,7 @@ spring:
     driver-class-name: org.h2.Driver
   sql:
     init:
-      mode: always
+      mode: never
       data-locations: classpath:data.sql
   jpa:
     hibernate:


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #90 

### 📝 반영 브랜치
>  feat/90 -> dev

### 📑 변경 사항
1. service 파일, schedular파일에 로그 추가하였습니다.
2. 기존 파워유저 정렬 방식이 활동점수로 되어있는데 Swagger에 정렬 Default가 ASC임을 확인하였습니다.
<img width="449" alt="스크린샷 2025-04-25 오전 12 52 58" src="https://github.com/user-attachments/assets/4affc208-eeb6-4235-a3d9-c00508d6c289" />

따라서, 활동점수가 아닌 등수rank로 설정 변경하였습니다.
<img width="952" alt="스크린샷 2025-04-25 오전 12 56 51" src="https://github.com/user-attachments/assets/0f2c604e-8388-48b9-9695-f329e94c9bca" />


### 🛠 테스트 결과
> 로컬사이트에서 테스트 추후 진행 예정입니다. 
기존 테스트코드 정상 작동 확인하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - `/api/users/power` 엔드포인트의 쿼리 파라미터 명확화 및 기본값/필수 여부 개선.

- **리팩터**
  - 파워 유저 배치 스케줄러가 하나의 스케줄 메서드로 통합되어 일괄 실행 및 에러 로그가 개선됨.
  - 파워 유저 정렬 기준이 점수에서 랭크로 변경됨.

- **스타일/로깅**
  - 회원가입, 로그인, 사용자 정보 처리 등 주요 서비스 동작에 대해 상세 로그가 추가되어 문제 추적이 용이해짐.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->