### PR TITLE
feat: notification controller, integration test add #112

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ jacoco {
 
 tasks.named('test') {
     useJUnitPlatform()
-//    ignoreFailures = true 테스트 실패 넘기는 코드
+//    ignoreFailures = true
     finalizedBy 'jacocoTestReport'
 }
 clean {

--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ jacoco {
 
 tasks.named('test') {
     useJUnitPlatform()
-    ignoreFailures = true
+//    ignoreFailures = true 테스트 실패 넘기는 코드
     finalizedBy 'jacocoTestReport'
 }
 clean {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.springframework.boot' version '3.4.4'
     id 'io.spring.dependency-management' version '1.1.7'
     id 'com.diffplug.spotless' version '6.25.0' // 빌드 시 코드 컨벤션 적용
+    id 'jacoco'
 }
 
 group = 'com.codeit'
@@ -91,9 +92,35 @@ tasks.named('build') {
     dependsOn 'spotlessApply'  // ✅ build 전에 코드 포맷 자동 적용
 }
 
+jacoco {
+    toolVersion = "0.8.10" // ➡️ 최신 버전 사용
+}
+
 tasks.named('test') {
     useJUnitPlatform()
+    ignoreFailures = true
+    finalizedBy 'jacocoTestReport'
 }
 clean {
     delete file('src/main/generated')
+}
+
+tasks.named('jacocoTestReport', JacocoReport).configure { report ->
+    dependsOn test
+
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+
+    // classDirectories 재설정: controller, service, repository 패키지만 포함
+    classDirectories.setFrom(
+            classDirectories.files.collect { File f ->
+                fileTree(dir: f, include: [
+                        'com/codeit/duckhu/domain/**/controller/**',
+                        'com/codeit/duckhu/domain/**/service/**',
+                        'com/codeit/duckhu/domain/**/repository/**'
+                ])
+            }
+    )
 }

--- a/src/main/java/com/codeit/duckhu/domain/notification/controller/api/NotificationApi.java
+++ b/src/main/java/com/codeit/duckhu/domain/notification/controller/api/NotificationApi.java
@@ -1,0 +1,165 @@
+package com.codeit.duckhu.domain.notification.controller.api;
+
+import com.codeit.duckhu.domain.notification.dto.CursorPageResponseNotificationDto;
+import com.codeit.duckhu.domain.notification.dto.NotificationDto;
+import com.codeit.duckhu.domain.notification.dto.NotificationUpdateRequest;
+import com.codeit.duckhu.domain.notification.service.NotificationService;
+import com.codeit.duckhu.domain.user.entity.User;
+import com.codeit.duckhu.domain.user.exception.UserException;
+import com.codeit.duckhu.global.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "알림 관리", description = "알림 관련 API")
+@RequestMapping("/api/notifications")
+public interface NotificationApi {
+
+    @Operation(summary = "알림 목록 조회", description = "사용자의 알림 목록을 조회합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "알림 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = CursorPageResponseNotificationDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (정렬 방향 오류, 페이지네이션 파라미터 오류, 사용자 ID 누락)",
+            content = @Content(schema = @Schema(implementation = CursorPageResponseNotificationDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "사용자 정보 없음",
+            content = @Content(schema = @Schema(implementation = CursorPageResponseNotificationDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(schema = @Schema(implementation = CursorPageResponseNotificationDto.class))
+        )
+    })
+    @GetMapping
+    ResponseEntity<CursorPageResponseNotificationDto> getNotifications(
+        @Parameter(
+            name = "userId",
+            description = "사용자 ID",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+            required = true,
+            in = ParameterIn.QUERY
+        )
+        @RequestParam UUID userId,
+        @Parameter(
+            name = "direction",
+            description = "정렬 방향 (ASC | DESC)",
+            example = "DESC",
+            in = ParameterIn.QUERY
+        )
+        @RequestParam(defaultValue = "DESC") String direction,
+        @Parameter(
+            name = "cursor",
+            description = "커서 페이지네이션 커서",
+            example = "2025-04-28T06:53:17.683Z",
+            in = ParameterIn.QUERY
+        )
+        @RequestParam(required = false) Instant cursor,
+        @Parameter(
+            name = "limit",
+            description = "페이지 크기",
+            example = "20",
+            in = ParameterIn.QUERY
+        )
+        @RequestParam(defaultValue = "20") int limit
+    );
+
+    @Operation(summary = "알림 읽음 상태 업데이트", description = "특정 알림의 읽음 상태를 업데이트합니다.")
+    @ApiResponses({
+        @ApiResponse(
+            responseCode = "200",
+            description = "알림 상태 업데이트 성공",
+            content = @Content(schema = @Schema(implementation = NotificationDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "400",
+            description = "잘못된 요청 (입력값 검증 실패, 요청자 ID 누락)",
+            content = @Content(schema = @Schema(implementation = NotificationDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "403",
+            description = "알림 수정 권한 없음",
+            content = @Content(schema = @Schema(implementation = NotificationDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "404",
+            description = "알림 정보 없음",
+            content = @Content(schema = @Schema(implementation = NotificationDto.class))
+        ),
+        @ApiResponse(
+            responseCode = "500",
+            description = "서버 내부 오류",
+            content = @Content(schema = @Schema(implementation = NotificationDto.class))
+        )
+    })
+    @PatchMapping("/{notificationId}")
+    ResponseEntity<NotificationDto> updateConfirmedStatus(
+        @Parameter(
+            name = "notificationId",
+            description = "알림 ID",
+            example = "123e4567-e89b-12d3-a456-426614174000",
+            required = true,
+            in = ParameterIn.PATH
+        )
+        @PathVariable UUID notificationId,
+        @Parameter(
+            name = "Deokhugam-Request-User-ID",
+            description = "요청자 ID",
+            in = ParameterIn.HEADER,
+            required = true,
+            example = "123e4567-e89b-12d3-a456-426614174000"
+        )
+        @RequestHeader("Deokhugam-Request-User-ID") UUID userId,
+        @RequestBody(
+            description = "읽음 여부 정보",
+            required = true,
+            content = @Content(schema = @Schema(implementation = NotificationUpdateRequest.class))
+        )
+        NotificationUpdateRequest request
+    );
+
+    @Operation(summary = "모든 알림 읽음 처리", description = "사용자의 모든 알림을 읽음 상태로 일괄 처리합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "알림 읽음 처리 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (사용자 ID 누락)"),
+        @ApiResponse(responseCode = "404", description = "사용자 정보 없음"),
+        @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @PatchMapping("/read-all")
+    ResponseEntity<Void> updateAllConfirmedStatus(
+        @Parameter(
+            name = "Deokhugam-Request-User-ID",
+            description = "요청자 ID",
+            in = ParameterIn.HEADER,
+            required = true,
+            example = "123e4567-e89b-12d3-a456-426614174000"
+        )
+        @RequestHeader("Deokhugam-Request-User-ID") UUID userId
+    );
+}

--- a/src/test/java/com/codeit/duckhu/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/codeit/duckhu/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,227 @@
+package com.codeit.duckhu.domain.notification.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.codeit.duckhu.domain.notification.dto.CursorPageResponseNotificationDto;
+import com.codeit.duckhu.domain.notification.dto.NotificationDto;
+import com.codeit.duckhu.domain.notification.dto.NotificationUpdateRequest;
+import com.codeit.duckhu.domain.notification.service.NotificationService;
+import com.codeit.duckhu.domain.user.UserAuthenticationFilter;
+import com.codeit.duckhu.domain.user.entity.User;
+import com.codeit.duckhu.domain.user.repository.UserRepository;
+import com.codeit.duckhu.global.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MockMvcBuilder;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@WebMvcTest(controllers = NotificationController.class)
+@Import({ GlobalExceptionHandler.class, UserAuthenticationFilter.class })
+@AutoConfigureMockMvc(addFilters = true)
+public class NotificationControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationService notificationService;
+
+    //인증 필터
+    @MockitoBean
+    private UserRepository userRepository;
+
+
+    @Nested
+    @DisplayName("GET /api/notifications")
+    class GetNotifications {
+
+        @Test
+        @DisplayName("성공 – 알림 페이지 응답")
+        void getNotifications_success() throws Exception {
+            // ── given ─────────────────────────────────────────────
+            UUID userId = UUID.randomUUID();
+            Instant now = Instant.now();
+
+            // 1) 필터를 통과시키기 위해 userRepository.findById(userId) stub
+            User mockUser = new User(/* email= */"a@b.com", /* nickname= */"test", /* password= */"pw");
+            // 엔티티에 ID 세팅이 필요하다면 리플렉션 등으로 setId() 해 주시고,
+            // 혹은 생성자에서 ID를 받도록 바꿔주세요.
+            ReflectionTestUtils.setField(mockUser, "id", userId);
+
+            given(userRepository.findById(userId))
+                .willReturn(Optional.of(mockUser));
+
+            // 2) notificationService.getNotifications(...) stub
+            NotificationDto dto1 = new NotificationDto(
+                UUID.randomUUID(), userId, UUID.randomUUID(),
+                "리뷰 A", "Alice님이 좋아합니다.", false,
+                now.minusSeconds(60), now.minusSeconds(60)
+            );
+            NotificationDto dto2 = new NotificationDto(
+                UUID.randomUUID(), userId, UUID.randomUUID(),
+                "리뷰 B", "Bob님이 댓글을 남겼습니다.", false,
+                now.minusSeconds(30), now.minusSeconds(30)
+            );
+            List<NotificationDto> content = List.of(dto1, dto2);
+            CursorPageResponseNotificationDto page = new CursorPageResponseNotificationDto(
+                content, null, null,
+                content.size(), content.size(), false
+            );
+            given(notificationService.getNotifications(
+                eq(userId), eq("DESC"), any(Instant.class), eq(2))
+            ).willReturn(page);
+
+            // ── when & then ────────────────────────────────────────
+            mockMvc.perform(get("/api/notifications")
+                    .param("userId", userId.toString())
+                    .param("direction", "DESC")
+                    .param("cursor", now.toString())
+                    .param("limit", "2")
+                    .sessionAttr("userId", userId)                // ← 여기
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content.length()").value(2))
+                .andExpect(jsonPath("$.content[0].content").value(dto1.content()))
+                .andExpect(jsonPath("$.hasNext").value(false));
+
+            then(notificationService)
+                .should()
+                .getNotifications(eq(userId), eq("DESC"), any(Instant.class), eq(2));
+        }
+
+        @Test
+        @DisplayName("실패 – 인증되지 않은 사용자는 401")
+        void getNotifications_unauthenticated() throws Exception {
+            mockMvc.perform(get("/api/notifications")
+                    .param("userId", UUID.randomUUID().toString())
+                )
+                .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/notifications/{notificationId}")
+    class UpdateConfirmedStatus {
+
+        @Test
+        @DisplayName("성공 – 단일 알림 읽음 처리")
+        void updateConfirmedStatus_success() throws Exception {
+            UUID userId = UUID.randomUUID();
+            UUID notificationId = UUID.randomUUID();
+            Instant now = Instant.now();
+
+            // 1) 인증 필터 통과용 stub
+            User mockUser = new User("a@b.com","nick","pw");
+            ReflectionTestUtils.setField(mockUser, "id", userId);
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+            // 2) 서비스 레이어 stub
+            NotificationDto updatedDto = new NotificationDto(
+                notificationId, userId, UUID.randomUUID(),
+                "리뷰 X", "[Tester]님이 좋아합니다.", true,
+                now.minusSeconds(5), now
+            );
+            given(notificationService.updateConfirmedStatus(notificationId, userId, true))
+                .willReturn(updatedDto);
+
+            // 3) 수행 & 검증
+            NotificationUpdateRequest req = new NotificationUpdateRequest(true);
+            mockMvc.perform(patch("/api/notifications/{id}", notificationId)
+                    .sessionAttr("userId", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(req))
+                )
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(notificationId.toString()))
+                .andExpect(jsonPath("$.confirmed").value(true));
+
+            then(notificationService)
+                .should().updateConfirmedStatus(notificationId, userId, true);
+        }
+
+        @Test
+        @DisplayName("실패 – 인증되지 않으면 401")
+        void updateConfirmedStatus_unauthenticated() throws Exception {
+            mockMvc.perform(patch("/api/notifications/{id}", UUID.randomUUID())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"confirmed\":true}")
+                )
+                .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패 – 잘못된 바디 형식으로 400")
+        void updateConfirmedStatus_badRequest() throws Exception {
+            UUID userId = UUID.randomUUID();
+            User mockUser = new User("a@b.com","nick","pw");
+            ReflectionTestUtils.setField(mockUser, "id", userId);
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+            // boolean으로 변환할 수 없는 값 전달 → 400 Bad Request
+            mockMvc.perform(patch("/api/notifications/{id}", UUID.randomUUID())
+                    .sessionAttr("userId", userId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("{\"confirmed\":\"notABoolean\"}")
+                )
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value("INTERNAL_SERVER_ERROR"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/notifications/read-all")
+    class UpdateAllConfirmedStatus {
+
+        @Test
+        @DisplayName("성공 – 모든 알림 일괄 읽음 처리")
+        void updateAllConfirmedStatus_success() throws Exception {
+            UUID userId = UUID.randomUUID();
+            User mockUser = new User("a@b.com","nick","pw");
+            ReflectionTestUtils.setField(mockUser, "id", userId);
+            given(userRepository.findById(userId)).willReturn(Optional.of(mockUser));
+
+            willDoNothing().given(notificationService).updateAllConfirmedStatus(userId);
+
+            mockMvc.perform(patch("/api/notifications/read-all")
+                    .sessionAttr("userId", userId)
+                )
+                .andExpect(status().isNoContent());
+
+            then(notificationService).should().updateAllConfirmedStatus(userId);
+        }
+
+        @Test
+        @DisplayName("실패 – 인증되지 않으면 401")
+        void updateAllConfirmedStatus_unauthenticated() throws Exception {
+            mockMvc.perform(patch("/api/notifications/read-all"))
+                .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/codeit/duckhu/domain/notification/integration/NotificationIntegrationTest.java
+++ b/src/test/java/com/codeit/duckhu/domain/notification/integration/NotificationIntegrationTest.java
@@ -1,0 +1,105 @@
+package com.codeit.duckhu.domain.notification.integration;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql(scripts = "/notifications.sql")
+class NotificationIntegrationTest {
+
+    private static final UUID RECEIVER_ID    = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID REVIEW_ID      = UUID.fromString("dddddddd-dddd-dddd-dddd-dddddddddddd");
+    private static final UUID NOTIFICATION_ID= UUID.fromString("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private MockHttpSession session;
+
+    @BeforeEach
+    void setUpSession() {
+        session = new MockHttpSession();
+        // SQL 에서 INSERT 한 receiver 유저의 ID
+        session.setAttribute("userId", RECEIVER_ID);
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications – 인증된 사용자는 내 알림 조회")
+    void listNotifications_success() throws Exception {
+        mockMvc.perform(get("/api/notifications")
+                .session(session)
+                .param("userId", RECEIVER_ID.toString())
+                .param("limit", "10")
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content.length()").value(1))
+            .andExpect(jsonPath("$.content[0].id").value(NOTIFICATION_ID.toString()))
+            .andExpect(jsonPath("$.content[0].reviewId").value(REVIEW_ID.toString()))
+            .andExpect(jsonPath("$.content[0].confirmed").value(false))
+            .andExpect(jsonPath("$.hasNext").value(false));
+    }
+
+    @Test
+    @DisplayName("GET /api/notifications – 인증 없으면 401")
+    void listNotifications_unauthorized() throws Exception {
+        mockMvc.perform(get("/api/notifications")
+                .param("userId", RECEIVER_ID.toString())
+            )
+            .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("PATCH /api/notifications/{id} – 단일 알림 읽음 처리")
+    void markOneAsRead_success() throws Exception {
+        var payload = objectMapper.writeValueAsString(
+            new com.codeit.duckhu.domain.notification.dto.NotificationUpdateRequest(true)
+        );
+
+        mockMvc.perform(patch("/api/notifications/{id}", NOTIFICATION_ID)
+                .session(session)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(payload)
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.id").value(NOTIFICATION_ID.toString()))
+            .andExpect(jsonPath("$.confirmed").value(true));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/notifications/read-all – 모든 알림 일괄 읽음 처리")
+    void markAllAsRead_success() throws Exception {
+        mockMvc.perform(patch("/api/notifications/read-all")
+                .session(session)
+            )
+            .andExpect(status().isNoContent());
+
+        // 처리 후 조회하면 confirmed=true 로 바뀌었는지 확인
+        mockMvc.perform(get("/api/notifications")
+                .session(session)
+                .param("userId", RECEIVER_ID.toString())
+            )
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].confirmed").value(true));
+    }
+}

--- a/src/test/java/com/codeit/duckhu/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/codeit/duckhu/domain/notification/service/NotificationServiceTest.java
@@ -18,6 +18,8 @@ import com.codeit.duckhu.domain.review.repository.ReviewRepository;
 import com.codeit.duckhu.domain.user.entity.User;
 import com.codeit.duckhu.domain.user.repository.UserRepository;
 import com.codeit.duckhu.global.type.PeriodType;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -51,6 +53,9 @@ public class NotificationServiceTest {
   @Mock private ReviewRepository reviewRepository;
 
   @Mock private UserRepository userRepository;
+
+  @Mock
+  private MeterRegistry meterRegistry;
 
   @InjectMocks private NotificationServiceImpl notificationService;
 
@@ -388,10 +393,14 @@ public class NotificationServiceTest {
     @Test
     @DisplayName("매일 00:30 기준 1분 지난 확인된 알림 삭제")
     void deleteConfirmedNotificationsOlderThanOneMinute() {
+      // given
+      Counter counter = mock(Counter.class);
+      given(meterRegistry.counter(anyString())).willReturn(counter);
+
       // when
       notificationService.deleteConfirmedNotificationsOlderThanAWeek();
 
-      // then: 서비스 내부에서 Instant.now().minus(1, ChronoUnit.MINUTES) 사용
+      // then
       then(notificationRepository).should(times(1))
           .deleteOldConfirmedNotifications(argThat(cutoff ->
               Duration.between(cutoff, Instant.now()).toMinutes() >= 1

--- a/src/test/resources/notifications.sql
+++ b/src/test/resources/notifications.sql
@@ -1,43 +1,69 @@
--- ================================
--- 1) USERS – 알림 수신자 및 트리거 유저
--- ================================
-INSERT INTO users (id, nickname, password, email, created_at, updated_at, is_deleted)
-VALUES
-    ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'receiver', 'pass', 'recv@example.com', now(), now(), false),
-    ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'trigger',  'pass', 'trig@example.com', now(), now(), false);
-
--- ================================
--- 2) BOOKS – 리뷰가 참조하는 도서
--- ================================
-INSERT INTO books (id, title, author, publisher, published_date, isbn, created_at, updated_at, is_deleted)
-VALUES
-    ('cccccccc-cccc-cccc-cccc-cccccccccccc', '테스트 도서', '홍길동', '테스트출판사', '2020-01-01', 'ISBN-1234', now(), now(), false);
-
--- ================================
--- 3) REVIEWS – 알림이 달릴 리뷰
--- ================================
-INSERT INTO reviews (
-    id, user_id, book_id, content, rating,
-    like_count, comment_count, is_deleted, created_at, updated_at
+DELETE FROM notifications;
+DELETE FROM reviews;
+DELETE FROM books;
+DELETE FROM users;
+-- 1) BOOKS – 리뷰가 참조하는 도서
+INSERT INTO books (
+    id, created_at, updated_at,
+    title, author, publisher,
+    published_date, isbn,
+    is_deleted, rating, review_count, thumbnail_url, description
 ) VALUES (
-             'dddddddd-dddd-dddd-dddd-dddddddddddd',  -- reviewId
-             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  -- 작성자(receiver)
-             'cccccccc-cccc-cccc-cccc-cccccccccccc',  -- 도서
-             '정말 재미있었어요!', 5,
-             2, 3, false, now(), now()
+             'cccccccc-cccc-cccc-cccc-cccccccccccc',
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP,
+             '테스트 도서',
+             '홍길동',
+             '테스트출판사',
+             '2020-01-01',
+             'ISBN-1234',
+             FALSE,        -- NOT NULL
+             0.0,          -- JPA DDL엔 기본값 없을 수도 있으니 안전하게 넣어주고
+             0,            -- 마찬가지
+             NULL,         -- nullable
+             NULL          -- nullable
          );
 
--- ================================
--- 4) NOTIFICATIONS – 미리 생성된 알림
--- ================================
+-- 2) USERS – 알림 수신자
+INSERT INTO users (
+    id, nickname, password, email,
+    created_at, is_deleted
+) VALUES (
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             'receiver',
+             'pass',
+             'recv@example.com',
+             CURRENT_TIMESTAMP,
+             FALSE
+         );
+
+-- 3) REVIEWS – 알림 대상 리뷰
+INSERT INTO reviews (
+    id, book_id, user_id, content, rating,
+    like_count, comment_count,
+    is_deleted, created_at, updated_at
+) VALUES (
+             'dddddddd-dddd-dddd-dddd-dddddddddddd',
+             'cccccccc-cccc-cccc-cccc-cccccccccccc',
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             '정말 재미있었어요!', 5,
+             0, 0,
+             FALSE,
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP
+         );
+
+-- 4) NOTIFICATIONS – 단일 알림
 INSERT INTO notifications (
     id, review_id, user_id, review_title, content,
     confirmed, created_at, updated_at
 ) VALUES (
-             'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',  -- notificationId
-             'dddddddd-dddd-dddd-dddd-dddddddddddd',  -- review_id
-             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',  -- user_id (receiver)
-             '정말 재미있었어요!',                     -- review_title
-             '[trigger]님이 나의 리뷰를 좋아합니다.',  -- content
-             false, now(), now()
+             'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+             'dddddddd-dddd-dddd-dddd-dddddddddddd',
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             '정말 재미있었어요!',
+             '[trigger]님이 나의 리뷰를 좋아합니다.',
+             FALSE,
+             CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP
          );


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev
feat/112 -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.
notification관련 controller, integrationtest추가

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
<img width="1566" alt="Image" src="https://github.com/user-attachments/assets/a59576bc-0f7b-4cd6-934e-ffd28d03eb3d" />

<img width="1573" alt="Image" src="https://github.com/user-attachments/assets/c0746079-0ed5-4d0a-ad10-fd88210a552f" />
### ✅ PR 올리기 전 체크리스트

- [ ] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [ ] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **테스트**
  - 알림 관련 API 엔드포인트에 대한 단위 테스트 및 통합 테스트가 추가되었습니다.
  - 인증된 사용자 및 비인증 사용자 시나리오, 알림 목록 조회, 단일/전체 알림 읽음 처리 등 다양한 성공 및 실패 케이스가 검증됩니다.
  - 알림 서비스의 삭제 기능에 대한 메트릭스 관련 모킹이 추가되었습니다.
- **Chores**
  - 테스트 데이터베이스 초기화 및 일관된 데이터 구성을 위한 SQL 스크립트가 개선되었습니다.
- **New Features**
  - 사용자 알림 관리를 위한 REST API 명세가 추가되었습니다.
- **Chores**
  - 코드 커버리지 측정을 위한 JaCoCo 플러그인이 빌드 설정에 도입되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->