### PR TITLE
[🐛Bug]amazoncoretto-alpine과 tess4j충돌해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+/logs
 
 ### Q classes
 **/generated/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,18 @@ COPY src ./src
 RUN ./gradlew clean build -x test --no-daemon
 
 #Jar파일 이미지에 저장하는 부분
-FROM amazoncorretto:17-alpine
+FROM eclipse-temurin:17-jdk-jammy
 
 ENV PROJECT_NAME=duckhu
 ENV PROJECT_VERSION=1.2-M8
 ENV JVM_OPTS=""
+
+# Tess4j 를 위한 필수 패키지 설치 (OCR 라이브러리)
+RUN apt-get update && apt-get install -y \
+    tesseract-ocr \
+    libtesseract-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 
 WORKDIR /app
 


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #121 

### 📝 반영 브랜치
> feat/121->dev

### 📑 문제 상황
amazoncoretto:17-alpine과 tess4j충돌로 도서 ISBN인식 안되는 상황

### 📑 변경 사항
dockerfile 의 amazoncoretto:17-alpine에서 
eclipse-temurin:17-jdk-jammy로 변경하였습니다.
(Java 17 + Ubuntu 계열 베이스 이미지를 써야 Tess4j + Tesseract 설치가 쉽다고 합니다.)
내부적으로 시스템에 깔린 tesseract-ocr 바이너리 호출을 위해 해당 코드를 추가하였습니다.
<img width="666" alt="스크린샷 2025-04-28 오후 5 04 54" src="https://github.com/user-attachments/assets/696d9827-23cb-426f-b211-3705e1532cab" />


### 🛠 테스트 결과
<img width="683" alt="스크린샷 2025-04-28 오후 5 12 06" src="https://github.com/user-attachments/assets/088a10c6-6660-4bf6-afe4-2451876264d3" />

>  ISBN으로 도서 등록됨을 확인하였습니다.
로그아웃 후 로그인 시도 시 정상 작동함을 확인하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - `.gitignore`에 `/logs` 디렉터리 제외 규칙을 추가하여 로그 디렉터리가 버전 관리에서 제외됩니다.
  - Docker 이미지의 기본 베이스를 `eclipse-temurin:17-jdk-jammy`로 변경하고, OCR 관련 패키지(`tesseract-ocr`, `libtesseract-dev`)를 추가로 설치합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->