### PR TITLE
[🛠Refactor]사용자 테스트코드 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
     //spring actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // session 통합테스트를 위한 HttpClient라이브러리
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'
 }
 
 spotless {

--- a/src/main/java/com/codeit/duckhu/domain/user/controller/UserController.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/controller/UserController.java
@@ -75,11 +75,8 @@ public class UserController implements UserApi {
       @PathVariable("userId") UUID targetId,
       @Valid @RequestBody UserUpdateRequest userUpdateRequest) {
     User authenticatedUser = (User) request.getAttribute("authenticatedUser");
-    if (authenticatedUser == null) { // 로그인 하지 않은 사용자가 들어왔을때
-      throw new UserException(ErrorCode.UNAUTHORIZED_USER);
-    }
     if (!targetId.equals(authenticatedUser.getId())) { // 로그인은 했지만 권한이 없을때 403 던지기
-      throw new UserException(ErrorCode.UNAUTHORIZED_USER);
+      throw new UserException(ErrorCode.UNAUTHORIZED_UPDATE);
     }
     UserDto result = userService.update(targetId, userUpdateRequest);
     return ResponseEntity.status(HttpStatus.OK).body(result);
@@ -90,11 +87,8 @@ public class UserController implements UserApi {
   public ResponseEntity<Void> softDelete(
       HttpServletRequest request, @PathVariable("userId") UUID targetId) {
     User authenticatedUser = (User) request.getAttribute("authenticatedUser");
-    if (authenticatedUser == null) { // 로그인 하지 않은 사용자가 들어왔을때
-      throw new UserException(ErrorCode.UNAUTHORIZED_USER);
-    }
     if (!targetId.equals(authenticatedUser.getId())) { // 로그인은 했지만 권한이 없을때 403 던지기
-      throw new UserException(ErrorCode.UNAUTHORIZED_USER);
+      throw new UserException(ErrorCode.UNAUTHORIZED_DELETE);
     }
     userService.softDelete(targetId);
     return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
@@ -105,9 +99,6 @@ public class UserController implements UserApi {
   public ResponseEntity<Void> hardDelete(
       HttpServletRequest request, @PathVariable("userId") UUID targetId) {
     User authenticatedUser = (User) request.getAttribute("authenticatedUser");
-    if (authenticatedUser == null) { // 로그인 하지 않은 사용자가 들어왔을때
-      throw new UserException(ErrorCode.UNAUTHORIZED_DELETE);
-    }
     if (!targetId.equals(authenticatedUser.getId())) { // 로그인은 했지만 권한이 없을때 403 던지기
       throw new UserException(ErrorCode.UNAUTHORIZED_DELETE);
     }

--- a/src/test/java/com/codeit/duckhu/domain/user/integration/UserTest.java
+++ b/src/test/java/com/codeit/duckhu/domain/user/integration/UserTest.java
@@ -46,15 +46,6 @@ public class UserTest {
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserRepository userRepository;
 
-  @Autowired private RestTemplateBuilder builder;
-
-  private TestRestTemplate templateWithSession;
-
-  @BeforeEach
-  void setUp() {
-    this.templateWithSession=restTemplate;
-  }
-
   private HttpHeaders getSessionHeader() throws Exception {
     UserLoginRequest loginRequest = new UserLoginRequest("test@example.com", "test1234!");
     HttpHeaders headers = new HttpHeaders();

--- a/src/test/java/com/codeit/duckhu/domain/user/integration/UserTest.java
+++ b/src/test/java/com/codeit/duckhu/domain/user/integration/UserTest.java
@@ -13,13 +13,17 @@ import com.codeit.duckhu.domain.user.dto.UserRegisterRequest;
 import com.codeit.duckhu.domain.user.dto.UserUpdateRequest;
 import com.codeit.duckhu.domain.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
 import java.util.UUID;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -41,6 +45,30 @@ public class UserTest {
 
   @Autowired private ObjectMapper objectMapper;
   @Autowired private UserRepository userRepository;
+
+  @Autowired private RestTemplateBuilder builder;
+
+  private TestRestTemplate templateWithSession;
+
+  @BeforeEach
+  void setUp() {
+    this.templateWithSession=restTemplate;
+  }
+
+  private HttpHeaders getSessionHeader() throws Exception {
+    UserLoginRequest loginRequest = new UserLoginRequest("test@example.com", "test1234!");
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    HttpEntity<String> entity = new HttpEntity<>(objectMapper.writeValueAsString(loginRequest), headers);
+    ResponseEntity<UserDto> response = restTemplate.postForEntity("/api/users/login", entity, UserDto.class);
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+
+    HttpHeaders responseHeaders = response.getHeaders();
+    String cookie = responseHeaders.getFirst(HttpHeaders.SET_COOKIE);
+    HttpHeaders sessionHeaders = new HttpHeaders();
+    sessionHeaders.set(HttpHeaders.COOKIE, cookie);
+    return sessionHeaders;
+  }
 
   @Test
   @DisplayName("사용자 생성-성공")
@@ -90,12 +118,12 @@ public class UserTest {
   @Test
   @DisplayName("사용자 상세 조회- 성공")
   @Sql("/data.sql")
-  void find_success() {
+  void find_success()throws Exception {
     // given
+    HttpHeaders sessionHeader = getSessionHeader();
     UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-    HttpHeaders headers = new HttpHeaders();
-    headers.set("Deokhugam-Request-User-ID", id.toString());
-    HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+
+    HttpEntity<Void> requestEntity = new HttpEntity<>(sessionHeader);
     // when
     ResponseEntity<UserDto> response =
         restTemplate.exchange("/api/users/" + id, HttpMethod.GET, requestEntity, UserDto.class);
@@ -111,13 +139,15 @@ public class UserTest {
   @Sql("/data.sql")
   void update_success() throws Exception {
     // given
+    HttpHeaders sessionHeader = getSessionHeader();
+    sessionHeader.setContentType(MediaType.APPLICATION_JSON);
+    sessionHeader.setAccept(List.of(MediaType.APPLICATION_JSON));
     UUID targetId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
     UserUpdateRequest request =new UserUpdateRequest("newName");
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.set("Deokhugam-Request-User-ID", targetId.toString());
+
+    sessionHeader.set("Deokhugam-Request-User-ID", targetId.toString());
     HttpEntity<String> httpEntity =
-        new HttpEntity<>(objectMapper.writeValueAsString(request), headers);
+        new HttpEntity<>(objectMapper.writeValueAsString(request), sessionHeader);
 
     // when
     ResponseEntity<UserDto> response =
@@ -132,13 +162,13 @@ public class UserTest {
   @Test
   @DisplayName("사용자 논리삭제 - 성공")
   @Sql("/data.sql")
-  void softDelete_success() {
+  void softDelete_success() throws Exception {
     // given
+    HttpHeaders sessionHeader = getSessionHeader();
     UUID targetId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.set("Deokhugam-Request-User-ID", targetId.toString());
-    HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+    sessionHeader.set("Deokhugam-Request-User-ID", targetId.toString());
+    HttpEntity<String> httpEntity = new HttpEntity<>(sessionHeader);
 
     // when
     ResponseEntity<Void> response =
@@ -151,13 +181,13 @@ public class UserTest {
   @Test
   @DisplayName("사용자 물리삭제 - 성공")
   @Sql("/data.sql")
-  void hardDelete_success() {
+  void hardDelete_success() throws Exception {
     // given
+    HttpHeaders sessionHeader = getSessionHeader();
     UUID targetId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.set("Deokhugam-Request-User-ID", targetId.toString());
-    HttpEntity<String> httpEntity = new HttpEntity<>(headers);
+
+    sessionHeader.set("Deokhugam-Request-User-ID", targetId.toString());
+    HttpEntity<String> httpEntity = new HttpEntity<>(sessionHeader);
 
     // when
     ResponseEntity<Void> response =

--- a/src/test/java/com/codeit/duckhu/domain/user/repository/PowerUserRepositoryTest.java
+++ b/src/test/java/com/codeit/duckhu/domain/user/repository/PowerUserRepositoryTest.java
@@ -1,16 +1,12 @@
 package com.codeit.duckhu.domain.user.repository;
 
-import com.codeit.duckhu.config.QueryDslConfig;
 import com.codeit.duckhu.domain.review.repository.TestJpaConfig;
 import com.codeit.duckhu.domain.user.dto.PowerUserStatsDto;
 import com.codeit.duckhu.domain.user.entity.PowerUser;
-import com.codeit.duckhu.domain.user.entity.User;
 import com.codeit.duckhu.domain.user.repository.poweruser.PowerUserRepository;
 import com.codeit.duckhu.domain.user.repository.poweruser.PowerUserRepositoryImpl;
 import com.codeit.duckhu.global.type.Direction;
 import com.codeit.duckhu.global.type.PeriodType;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,4 +72,27 @@ public class PowerUserRepositoryTest {
         assertThat(result).hasSizeLessThanOrEqualTo(limit);
         assertThat(result).isSortedAccordingTo(Comparator.comparing(PowerUser::getScore));
     }
+
+    @Test
+    @DisplayName("커서 없이 첫 페이지 DESC정렬 조회 성공")
+    void searchPowerUserStats_desc() {
+        //given
+        Instant after = Instant.now().minus(30, ChronoUnit.DAYS);
+        int limit = 10;
+
+        //when
+        List<PowerUser> result = powerUserRepository.searchByPeriodWithCursorPaging(
+                PeriodType.MONTHLY,
+                Direction.DESC,
+                null,
+                after,
+                limit
+        );
+
+        //then
+        assertThat(result).isNotEmpty();
+        assertThat(result).hasSizeLessThanOrEqualTo(limit);
+        assertThat(result).isSortedAccordingTo(Comparator.comparing(PowerUser::getScore).reversed());
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #89 

### 📝 반영 브랜치
>  feat/89 -> dev

### 📑 변경 사항
> 테스트에 세션 도입 위해 의존성을 추가해두었습니다.
`implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.1'`

필터에서 로그인 인증을 하기 때문에 컨트롤러에서 로그인 검증 분기부분을 제거하였습니다.


### 🛠 테스트 결과

- 컨트롤러 단위테스트

<img width="431" alt="스크린샷 2025-04-28 오후 11 29 20" src="https://github.com/user-attachments/assets/01ffceed-6965-4326-be35-895affc7cb69" />

- 통합테스트
<img width="425" alt="스크린샷 2025-04-28 오후 11 30 11" src="https://github.com/user-attachments/assets/46d2a278-345d-409c-b974-1aafd0d86cc2" />

- repository테스트
<img width="336" alt="스크린샷 2025-04-28 오후 11 30 42" src="https://github.com/user-attachments/assets/0a4eff0c-1c61-45ab-8ea4-6ec25eed07bb" />
  


<img width="362" alt="스크린샷 2025-04-28 오후 11 31 03" src="https://github.com/user-attachments/assets/9a9d94b7-782b-4588-87d6-d6fd5778c06e" />

- 서비스 단위테스트

<img width="417" alt="스크린샷 2025-04-28 오후 11 31 32" src="https://github.com/user-attachments/assets/9344a5da-b0ef-494d-a25b-6161a12265f0" />


### ✅ 추가 코멘트
- 컨트롤러 테스트에서 성공로직을 검증하지 않은 이유는 통합테스트에서 성공을 보장하기 때문입니다.
- 추후 부족한 부분이 보이면 리팩토링 진행 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
    - 사용자 관련 API에서 인증 및 권한 오류 처리 방식을 개선했습니다. 인증되지 않은 요청에 대해 더 명확한 오류 응답을 제공합니다.

- **테스트**
    - 사용자 컨트롤러 및 통합 테스트에 세션 기반 인증 시나리오를 추가하여, 인증 및 권한 관련 테스트 커버리지를 확대했습니다.
    - PowerUser 통계 조회에 대한 내림차순 정렬 테스트가 추가되었습니다.

- **기타**
    - 세션 통합 테스트를 위한 Apache HttpClient 5 라이브러리가 빌드에 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->