### PR TITLE
:recycle: release 브랜치를 제외시킴

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -137,29 +137,3 @@ jobs:
           cluster: deokhugam-cluster
           task-definition: ecs/task-definition.json
           force-new-deployment: true
-
-  create_release_pr:
-    name: 📝 릴리즈 PR 생성
-    if: github.event.pull_request.merged == true && needs.set_environment.outputs.environment == 'dev'
-    runs-on: ubuntu-latest
-    needs: [set_environment]
-    steps:
-      - name: 코드 체크아웃
-        uses: actions/checkout@v4
-
-      - name: GitHub 인증
-        run: |
-          echo "${{ secrets.PERSONAL_ACCESS_TOKEN }}" | gh auth login --with-token
-
-      - name: 릴리즈 브랜치 생성
-        run: |
-          git checkout -b release/${{ github.run_id }}
-          git push origin release/${{ github.run_id }}
-
-      - name: 릴리즈 PR 생성
-        run: |
-          gh pr create \
-            --base main \
-            --head release/${{ github.run_id }} \
-            --title "🚀 Release PR: ${{ github.run_id }}" \
-            --body-file .github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [x] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

feat/144 -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- 기존에 dev에 머지하면 자동으로 release 브랜치가 생성되고 PR도 자동생성되도록 설정했습니다.
- 하지만 이 방법보다는 수동으로 main에 PR를 생성하는 것이 더 좋을 것 같다고 판단하여 수정하였습니다.

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

![image](https://github.com/user-attachments/assets/799b8790-6fa4-4b62-a8b9-4ac1f9b6a700)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - GitHub Actions 워크플로우에서 자동 릴리즈 PR 생성 작업이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->