### PR TITLE
Docker 컨테이너에서 시간대 설정 누락으로 인한 9시간 오차 문제 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,4 @@ EXPOSE 80
 
 #sh=shell -c=해당 명령어 실행 $JVM_OPTS= ENTRY실행될때까지 몰라.
 #그냥 java로 하면 환경변수 그대로 문자열로 인식해서 JVM_OPTS는 값이 안들어가게됨.
-ENTRYPOINT ["sh","-c","java $JVM_OPTS -jar app.jar"]
+ENTRYPOINT ["sh","-c","java -Duser.timezone=Asia/Seoul $JVM_OPTS -jar app.jar"]


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

#166 

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [ ] 기능 수정 (Enhancement)
- [x] 버그 수정 (Bugfix)
- [ ] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

- feat/166 -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

- JVM 타임존을 Asia/Seoul로 명시하여 서버 응답 시간 KST로 일관성 확보

### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

![스크린샷 2025-05-02 145456](https://github.com/user-attachments/assets/d4fbef4b-2979-4aaf-8411-ec59d9eb2ad5)
![스크린샷 2025-05-02 145445](https://github.com/user-attachments/assets/6394976a-983f-4988-ae2f-536c51f0cd4b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 애플리케이션이 항상 Asia/Seoul 시간대에서 실행되도록 기본 시간대 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->