### PR TITLE
[🛠Refactor] Loki적용으로 그라파나에서 로그 확인

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ src/main/resources/vision-key.json
 # log
 logs/
 
-#grafana
+#monitoring
 monitoring/grafana-data/
 monitoring/prometheus-data/
 monitoring/loki-data/

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ logs/
 #grafana
 monitoring/grafana-data/
 monitoring/prometheus-data/
+monitoring/loki-data/
+monitoring/positions.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,32 @@ services:
       - ./monitoring/grafana-data:/var/lib/grafana
     depends_on:
       - prometheus
+      - loki
+
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    networks:
+      - monitoring-network
+    ports:
+      - "3100:3100"
+    command:
+      - '--config.file=/etc/loki/loki-config.yml'
+    volumes:
+      - ./monitoring/loki-config.yml:/etc/loki/loki-config.yml
+      - ./monitoring/loki-data:/loki
+
+  promtail:
+    container_name: promtail
+    image: grafana/promtail:latest
+    networks:
+      - monitoring-network
+    volumes:
+      - ./monitoring/promtail-config.yml:/etc/promtail/promtail-config.yml
+      - ./monitoring/positions.yml:/etc/promtail/positions.yml
+      - ./logs:/logs
+    command:
+      - '--config.file=/etc/promtail/promtail-config.yml'
 
   node-exporter:
     image: prom/node-exporter:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
       - "80:8080"
     environment:
+      - TZ=Asia/Seoul
       - NAVER_CLIENT_ID=${NAVER_CLIENT_ID}
       - NAVER_CLIENT_SECRET=${NAVER_CLIENT_SECRET}
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
@@ -109,6 +110,7 @@ services:
 networks:
   monitoring-network:
     driver: bridge
+
 
 
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     ports:
       - "80:8080"
     environment:
-      - TZ=Asia/Seoul
       - NAVER_CLIENT_ID=${NAVER_CLIENT_ID}
       - NAVER_CLIENT_SECRET=${NAVER_CLIENT_SECRET}
       - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE}
@@ -94,8 +93,7 @@ services:
       - monitoring-network
     volumes:
       - ./monitoring/promtail-config.yml:/etc/promtail/promtail-config.yml
-      - ./monitoring/positions.yml:/etc/promtail/positions.yml
-      - ./logs:/logs
+      - ./logs:/app/logs
     command:
       - '--config.file=/etc/promtail/promtail-config.yml'
 

--- a/monitoring/loki-config.yml
+++ b/monitoring/loki-config.yml
@@ -1,0 +1,30 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+limits_config:
+  allow_structured_metadata: false
+
+schema_config:
+  configs:
+    - from: 2025-05-02
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+ruler:
+  alertmanager_url: http://localhost:9093

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /etc/promtail/positions.yml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: system-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: was-log
+          __path__: /logs/deokhugam.log

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -3,7 +3,7 @@ server:
   grpc_listen_port: 0
 
 positions:
-  filename: /etc/promtail/positions.yml
+  filename: /tmp/promtail-positions.yml
 
 clients:
   - url: http://host.docker.internal:3100/loki/api/v1/push
@@ -15,4 +15,4 @@ scrape_configs:
           - localhost
         labels:
           job: was-log
-          __path__: /logs/deokhugam.log
+          __path__: /app/logs/deokhugam.log

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -6,7 +6,7 @@ positions:
   filename: /etc/promtail/positions.yml
 
 clients:
-  - url: http://loki:3100/loki/api/v1/push
+  - url: http://host.docker.internal:3100/loki/api/v1/push
 
 scrape_configs:
   - job_name: system-logs


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #154 

### 📝 반영 브랜치
> feat/154 -> dev

### 📑 변경 사항
> 그라파나에서 로그 확인 할 수 있도록 Loki를 도입해보았습니다.
실시간 로그가 찍히지 않아서 배포 서버의 그라파나 작업 진행 후 해결할 예정입니다.

### 🛠 테스트 결과
<img width="1407" alt="스크린샷 2025-05-02 오후 4 03 36" src="https://github.com/user-attachments/assets/e2e9d854-f55e-4634-b697-7855e09fe0a7" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - Loki 및 Promtail 기반의 로그 수집 및 모니터링 시스템이 도입되었습니다.
  - 애플리케이션 서비스의 표준 시간대가 Asia/Seoul로 설정되었습니다.

- **기타**
  - `.gitignore`에 모니터링 관련 데이터 및 설정 파일이 추가되어 불필요한 파일이 버전 관리에서 제외됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->