### PR TITLE
[🛠Refactor] 파워유저 수정

### DIFF
--- a/src/main/java/com/codeit/duckhu/domain/user/repository/poweruser/PowerUserRepositoryImpl.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/repository/poweruser/PowerUserRepositoryImpl.java
@@ -131,21 +131,19 @@ public class PowerUserRepositoryImpl implements PowerUserRepositoryCustom {
   }
 
   private BooleanBuilder getCursorCondition(String cursor, Instant after, boolean isAsc) {
-    UUID cursorId = UUID.fromString(cursor);
+    int cursorRank = Integer.parseInt(cursor);
     BooleanBuilder builder = new BooleanBuilder();
 
     if (isAsc) {
       builder.and(
-          powerUser
-              .createdAt
-              .gt(after)
-              .or(powerUser.createdAt.eq(after).and(powerUser.user.id.gt(cursorId))));
+              powerUser.rank.gt(cursorRank)
+                      .or(powerUser.rank.eq(cursorRank).and(powerUser.createdAt.gt(after)))
+      );
     } else {
       builder.and(
-          powerUser
-              .createdAt
-              .lt(after)
-              .or(powerUser.createdAt.eq(after).and(powerUser.user.id.lt(cursorId))));
+              powerUser.rank.lt(cursorRank)
+                      .or(powerUser.rank.eq(cursorRank).and(powerUser.createdAt.lt(after)))
+      );
     }
 
     return builder;

--- a/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
@@ -187,12 +187,11 @@ public class UserServiceImpl implements UserService {
     try {
       Instant now = Instant.now();
       Instant start = period.toStartInstant(now);
-      Instant end = now;
 
       log.info("[Batch 시작] period={} | from={} ~ to={}", period, start, now);
 
       // 계산에 필요한 요소들 갖고오기
-      List<PowerUserStatsDto> stats = powerUserRepository.findPowerUserStatsBetween(start, end);
+      List<PowerUserStatsDto> stats = powerUserRepository.findPowerUserStatsBetween(start, now);
 
       // 유저목록가져오기
       Set<UUID> userIds = stats.stream().map(PowerUserStatsDto::userId).collect(Collectors.toSet());
@@ -269,13 +268,15 @@ public class UserServiceImpl implements UserService {
 
 
     // 저장된 PowerUser 커서페이지로 갖고오기
-    List<PowerUser> pageContent = hasNext ? powerUsers.subList(0, limit) : powerUsers;
-    List<PowerUserDto> list = pageContent.stream().map(powerUserMapper::toDto).toList();
+    if (hasNext) {
+      powerUsers = powerUsers.subList(0, limit);
+    }
+    List<PowerUserDto> list = powerUsers.stream().map(powerUserMapper::toDto).toList();
 
     String nextCursor = null;
     Instant nextAfter = null;
-    if (hasNext && !pageContent.isEmpty()) {
-      PowerUser last = pageContent.get(pageContent.size() - 1);
+    if (hasNext && !powerUsers.isEmpty()) {
+      PowerUser last = powerUsers.get(powerUsers.size() - 1);
       nextCursor = String.valueOf(last.getRank());
       nextAfter = last.getCreatedAt();
     }

--- a/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/codeit/duckhu/domain/user/service/UserServiceImpl.java
@@ -276,7 +276,7 @@ public class UserServiceImpl implements UserService {
     Instant nextAfter = null;
     if (hasNext && !pageContent.isEmpty()) {
       PowerUser last = pageContent.get(pageContent.size() - 1);
-      nextCursor = last.getUser().getId().toString();
+      nextCursor = String.valueOf(last.getRank());
       nextAfter = last.getCreatedAt();
     }
 

--- a/src/test/java/com/codeit/duckhu/domain/user/repository/PowerUserRepositoryTest.java
+++ b/src/test/java/com/codeit/duckhu/domain/user/repository/PowerUserRepositoryTest.java
@@ -36,7 +36,7 @@ public class PowerUserRepositoryTest {
   void powerUserStats_success() {
     // given
     Instant now = Instant.now();
-    Instant start = now.minus(1, ChronoUnit.DAYS);
+    Instant start = now.minus(2, ChronoUnit.DAYS);
 
     // when
     List<PowerUserStatsDto> stats = powerUserRepository.findPowerUserStatsBetween(start, now);


### PR DESCRIPTION
## #️⃣ 연관 이슈
> #180 

### 📝 반영 브랜치
>  feat/180 -> dev

### 📑 변경 사항
> 커서 기준을 rank, createdAt으로 수정하였습니다.
리뷰 좋아요 댓글 중 하나라도 포함되면 파워유저에 적용되도록 수정하였습니다.
applicaiton-test.yml가 test폴더의 resources 폴더에서 사라져서 파워유저 테스트가 실패했던 것 같습니다. 
다시 넣어주니 성공하였습니다.

### 🛠 테스트 결과
<img width="274" alt="스크린샷 2025-05-08 오후 2 40 26" src="https://github.com/user-attachments/assets/9b19e2d1-6051-4d57-9172-f24caacae42e" />

### ✅ 추가코멘트
application-test.yml 파일입니다.
```
server:
  port: 8081

spring:
  datasource:
    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
    username: sa
    password:
    driver-class-name: org.h2.Driver
  sql:
    init:
      mode: never
      data-locations: classpath:data.sql
  jpa:
    hibernate:
      ddl-auto: create-drop
    properties:
      hibernate:
        dialect: org.hibernate.dialect.H2Dialect
        format_sql: true


logging:
  level:
    com.sprint.mission.discodeit: debug
    org.hibernate.SQL: debug
    org.hibernate.orm.jdbc.bind: trace
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - 파워 유저 통계 집계 방식이 개선되어, 리뷰 점수, 좋아요 수, 댓글 수를 모두 포함하도록 통합되었습니다.
  - 페이지네이션 커서가 사용자 ID에서 랭크 기반으로 변경되어 더 일관된 정렬 및 탐색이 가능합니다.
  - 내부 변수 및 리스트 처리 방식이 간소화되었습니다.

- **테스트**
  - 파워 유저 통계 테스트의 조회 기간이 1일에서 2일로 확장되어 더 많은 데이터를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->